### PR TITLE
fix: upgrade dependencies to resolve HIGH severity vulnerabilities

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 aiohappyeyeballs==2.6.1
-aiohttp==3.11.18
-aiosignal==1.3.2
+aiohttp==3.13.3
+aiosignal==1.4.0
 alembic==1.15.1
 amqp==5.3.1
 anyio==4.9.0
@@ -28,14 +28,14 @@ email-validator==2.1.0.post1
 executing==2.2.0
 Flask==3.0.2
 Flask-Admin==1.6.1
-Flask-Cors==4.0.0
+Flask-Cors==4.0.2
 Flask-Limiter==3.12
 Flask-Mail==0.9.1
 Flask-Migrate==4.0.5
 Flask-SQLAlchemy==3.1.1
 flower==2.0.1
 frozenlist==1.6.0
-gunicorn==21.2.0
+gunicorn==22.0.0
 h11==0.16.0
 httpcore==1.0.9
 httpx==0.28.1
@@ -105,7 +105,7 @@ tornado==6.5.2
 traitlets==5.14.3
 typing_extensions==4.12.2
 tzdata==2025.2
-urllib3==2.3.0
+urllib3==2.6.3
 vine==5.1.0
 wcwidth==0.2.13
 websockets==15.0.1


### PR DESCRIPTION
## Summary
- Upgrade **aiohttp** 3.11.18 → 3.13.3 (fixes DoS via zip bomb, request smuggling)
- Upgrade **aiosignal** 1.3.2 → 1.4.0 (required by aiohttp 3.13.3)
- Upgrade **gunicorn** 21.2.0 → 22.0.0 (fixes HTTP request smuggling via Transfer-Encoding)
- Upgrade **Flask-Cors** 4.0.0 → 4.0.2 (fixes Access-Control-Allow-Private-Network default)
- Upgrade **urllib3** 2.3.0 → 2.6.3 (fixes redirect handling, decompression bomb, SSRF)

Resolves all 7 HIGH severity Dependabot alerts. Remaining alerts are medium/low.

## Test plan
- [x] All 192 tests pass after upgrades
- [x] `pip-audit` confirms no HIGH severity vulnerabilities remain
- [x] No breaking changes from dependency upgrades

Closes #10