### PR TITLE
test: restore S3 error-path tests for audio model

### DIFF
--- a/tests/test_models/test_audio_model.py
+++ b/tests/test_models/test_audio_model.py
@@ -193,3 +193,167 @@ class TestAudioModel:
 
             assert success is True
             assert AudioStory.query.filter_by(voice_id=voice.id).count() == 0
+
+    def test_get_audio_with_range(self, app):
+        """Test Range header forwarding to S3 for audio streaming"""
+        with app.app_context():
+            user = User(email="range-audio@example.com", is_active=True, email_confirmed=True)
+            user.set_password("Password123!")
+            db.session.add(user)
+            db.session.commit()
+
+            story = Story(title="Test", author="Author", description="Desc", content="Content")
+            db.session.add(story)
+            db.session.commit()
+
+            voice = Voice(
+                name="Test Voice", user_id=user.id,
+                status=VoiceStatus.READY, allocation_status=VoiceAllocationStatus.READY,
+                service_provider=VoiceServiceProvider.ELEVENLABS,
+            )
+            db.session.add(voice)
+            db.session.commit()
+
+            audio_record = AudioStory(
+                story_id=story.id, voice_id=voice.id, user_id=user.id,
+                status=AudioStatus.READY.value,
+                s3_key="audio_stories/test/1.mp3",
+            )
+            db.session.add(audio_record)
+            db.session.commit()
+
+            mock_body = MagicMock()
+            mock_body.read.return_value = b'partial audio data'
+            mock_s3 = MagicMock()
+            mock_s3.get_object.return_value = {
+                'Body': mock_body,
+                'ContentLength': 18,
+                'ContentType': 'audio/mpeg',
+                'ContentRange': 'bytes 0-17/1000',
+            }
+
+            with patch('utils.s3_client.S3Client.get_client', return_value=mock_s3), \
+                 patch('utils.s3_client.S3Client.get_bucket_name', return_value='test-bucket'):
+                success, content, extra = AudioModel.get_audio(
+                    voice.id, story.id, range_header="bytes=0-17"
+                )
+
+            assert success is True
+            assert content == b'partial audio data'
+            assert extra['content_range'] == 'bytes 0-17/1000'
+            mock_s3.get_object.assert_called_once_with(
+                Bucket='test-bucket',
+                Key='audio_stories/test/1.mp3',
+                Range='bytes=0-17',
+            )
+
+    def test_get_audio_s3_error(self, app):
+        """Test S3 ClientError handling during audio retrieval"""
+        with app.app_context():
+            user = User(email="s3err-audio@example.com", is_active=True, email_confirmed=True)
+            user.set_password("Password123!")
+            db.session.add(user)
+            db.session.commit()
+
+            story = Story(title="Test", author="Author", description="Desc", content="Content")
+            db.session.add(story)
+            db.session.commit()
+
+            voice = Voice(
+                name="Test Voice", user_id=user.id,
+                status=VoiceStatus.READY, allocation_status=VoiceAllocationStatus.READY,
+                service_provider=VoiceServiceProvider.ELEVENLABS,
+            )
+            db.session.add(voice)
+            db.session.commit()
+
+            audio_record = AudioStory(
+                story_id=story.id, voice_id=voice.id, user_id=user.id,
+                status=AudioStatus.READY.value,
+                s3_key="audio_stories/test/1.mp3",
+            )
+            db.session.add(audio_record)
+            db.session.commit()
+
+            mock_s3 = MagicMock()
+            mock_s3.get_object.side_effect = ClientError(
+                {'Error': {'Code': 'NoSuchKey', 'Message': 'Not Found'}},
+                'GetObject',
+            )
+
+            with patch('utils.s3_client.S3Client.get_client', return_value=mock_s3), \
+                 patch('utils.s3_client.S3Client.get_bucket_name', return_value='test-bucket'):
+                success, message, extra = AudioModel.get_audio(voice.id, story.id)
+
+            assert success is False
+            assert "not found" in message.lower()
+            assert extra is None
+
+    def test_delete_voice_audio_s3_error(self, app):
+        """Test S3 error handling during voice audio deletion"""
+        with app.app_context():
+            user = User(email="del-s3err@example.com", is_active=True, email_confirmed=True)
+            user.set_password("Password123!")
+            db.session.add(user)
+            db.session.commit()
+
+            story = Story(title="Test", author="Author", description="Desc", content="Content")
+            db.session.add(story)
+            db.session.commit()
+
+            voice = Voice(
+                name="Test Voice", user_id=user.id,
+                status=VoiceStatus.READY, allocation_status=VoiceAllocationStatus.READY,
+                service_provider=VoiceServiceProvider.ELEVENLABS,
+            )
+            db.session.add(voice)
+            db.session.commit()
+
+            audio_record = AudioStory(
+                story_id=story.id, voice_id=voice.id, user_id=user.id,
+                status=AudioStatus.READY.value,
+                s3_key="audio_stories/test/1.mp3",
+            )
+            db.session.add(audio_record)
+            db.session.commit()
+
+            with patch('utils.s3_client.S3Client.delete_objects', return_value=(False, 0, ['error deleting'])):
+                success, message = AudioModel.delete_voice_audio(voice.id)
+
+            assert success is True
+            assert "issues with S3" in message
+            assert AudioStory.query.filter_by(voice_id=voice.id).count() == 0
+
+    def test_delete_voice_audio_no_files(self, app):
+        """Test deletion edge case when records exist but have no S3 keys"""
+        with app.app_context():
+            user = User(email="del-nofiles@example.com", is_active=True, email_confirmed=True)
+            user.set_password("Password123!")
+            db.session.add(user)
+            db.session.commit()
+
+            story = Story(title="Test", author="Author", description="Desc", content="Content")
+            db.session.add(story)
+            db.session.commit()
+
+            voice = Voice(
+                name="Test Voice", user_id=user.id,
+                status=VoiceStatus.READY, allocation_status=VoiceAllocationStatus.READY,
+                service_provider=VoiceServiceProvider.ELEVENLABS,
+            )
+            db.session.add(voice)
+            db.session.commit()
+
+            audio_record = AudioStory(
+                story_id=story.id, voice_id=voice.id, user_id=user.id,
+                status=AudioStatus.PENDING.value,
+                s3_key=None,
+            )
+            db.session.add(audio_record)
+            db.session.commit()
+
+            success, message = AudioModel.delete_voice_audio(voice.id)
+
+            assert success is True
+            assert "no s3 files" in message.lower()
+            assert AudioStory.query.filter_by(voice_id=voice.id).count() == 0


### PR DESCRIPTION
## Summary
- Adds 4 tests covering S3 error paths in `AudioModel` that were missing from the test suite
- Tests Range header forwarding, S3 `ClientError` handling on retrieval, S3 errors during deletion, and the edge case of deleting records with no S3 files

## Tests added
| Test | What it covers |
|------|---------------|
| `test_get_audio_with_range` | Range header forwarding to S3 for audio streaming |
| `test_get_audio_s3_error` | S3 `ClientError` (`NoSuchKey`) handling during audio retrieval |
| `test_delete_voice_audio_s3_error` | S3 error handling during voice audio deletion |
| `test_delete_voice_audio_no_files` | Deletion when records exist but have no S3 keys |

## Test plan
- [x] All 4 new tests pass locally
- [x] Full test suite (214 tests) passes with no regressions

Closes #13