### PR TITLE
fix: add missing celery-redbeat dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,7 @@ boto3==1.34.1
 botocore==1.34.162
 cartesia==1.0.0
 celery==5.3.6
+celery-redbeat==2.3.3
 certifi==2025.1.31
 charset-normalizer==3.4.1
 click==8.1.8


### PR DESCRIPTION
## Summary
- Adds `celery-redbeat==2.3.3` to `requirements.txt`
- The app configures `redbeat.RedBeatScheduler` as the Celery beat scheduler (in `app.py:73`) but the package was never listed as a dependency, causing 108 `ModuleNotFoundError` occurrences in production

## Test plan
- [ ] `pip install -r requirements.txt` succeeds
- [ ] Celery beat starts without `ModuleNotFoundError: No module named 'redbeat'`

Closes #20