### PR TITLE
fix: disable Sentry SDK during test runs

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -12,6 +12,7 @@ addopts = -v
 
 # Environment variables for testing
 env =
+    SENTRY_DSN=
     ELEVENLABS_API_KEY=test_api_key
     AWS_ACCESS_KEY_ID=test_aws_key
     AWS_SECRET_ACCESS_KEY=test_aws_secret

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,6 +22,7 @@ from database import db
 def setup_test_environment():
     """Set up test environment variables and directories"""
     # Set environment variables for testing
+    os.environ["SENTRY_DSN"] = ""
     os.environ["ELEVENLABS_API_KEY"] = "test_api_key"
     os.environ["CARTESIA_API_KEY"] = "test_cartesia_api_key"
     os.environ["AWS_ACCESS_KEY_ID"] = "test_aws_key"


### PR DESCRIPTION
## Summary
- Adds `SENTRY_DSN=` (empty) to `pytest.ini` env section so pytest-env clears it before any imports
- Adds `os.environ["SENTRY_DSN"] = ""` to `conftest.py` setup fixture as a safety net

## Root Cause
CI already had `SENTRY_DSN=""` in the workflow env, but local test runs could inherit a real `SENTRY_DSN` from the developer's `.env` file, causing Sentry to initialize and report test errors/noise to production monitoring.

## Test plan
- [ ] `pytest` runs without Sentry initialization messages
- [ ] No test errors sent to Sentry dashboard
- [ ] CI continues to pass (already had `SENTRY_DSN=""`)

Closes #23