### PR TITLE
chore: add .claudeignore

### DIFF
--- a/.claudeignore
+++ b/.claudeignore
@@ -1,0 +1,7 @@
+venv/
+.venv/
+__pycache__/
+.pytest_cache/
+migrations/
+tests/fixtures/
+*.mp3


### PR DESCRIPTION
Excludes venv, __pycache__, .pytest_cache, migrations, fixtures, mp3 from Claude Code indexing.