### PR TITLE
feat: gate subscription enforcement behind ENFORCE_SUBSCRIPTION_GATE flag

### DIFF
--- a/config.py
+++ b/config.py
@@ -130,6 +130,24 @@ class Config:
     except Exception:
         _ic_val = 10
     INITIAL_CREDITS = _ic_val if _ic_val >= 0 else 10
+
+    # Subscription gate feature flag.
+    #
+    # When False (default), the audio synthesis gate in audio_controller is
+    # bypassed and old mobile clients that cannot handle the
+    # `SUBSCRIPTION_REQUIRED` error code keep working. Subscription data
+    # (trial_expires_at, subscription_active, webhooks, addon grants, etc.)
+    # is still recorded correctly; only enforcement is disabled.
+    #
+    # Flip to True only after >=95% of active users are on a mobile build
+    # that handles the gate. See SUBSCRIPTION_MOBILE_REQUIREMENTS.md for the
+    # flip-day runbook (includes a trial-refresh SQL to reset stale trial
+    # windows for users who signed up during the flag-off period).
+    ENFORCE_SUBSCRIPTION_GATE = (
+        os.getenv("ENFORCE_SUBSCRIPTION_GATE", "false").strip().lower()
+        in ("1", "true", "yes", "on")
+    )
+
     # RevenueCat / Subscription
     REVENUECAT_WEBHOOK_SECRET = os.getenv("REVENUECAT_WEBHOOK_SECRET")
     REVENUECAT_API_KEY = os.getenv("REVENUECAT_API_KEY")

--- a/controllers/audio_controller.py
+++ b/controllers/audio_controller.py
@@ -1,6 +1,7 @@
 import logging
 from typing import Tuple
 
+from config import Config
 from database import db
 from models.audio_model import AudioModel, AudioStatus, AudioStory
 from models.story_model import StoryModel
@@ -90,13 +91,18 @@ class AudioController:
             if not voice:
                 return False, {"error": "Voice not found"}, 404
 
-            # Gate: verify the voice's owner has an active subscription or trial
-            gate_user = UserModel.get_by_id(voice.user_id)
-            if not gate_user:
-                logger.warning("Voice %s owned by non-existent user %s", voice_id, voice.user_id)
-                return False, {"error": "Voice owner account not found", "code": "USER_NOT_FOUND"}, 404
-            if not gate_user.can_generate:
-                return False, {"error": "Subscription required", "code": "SUBSCRIPTION_REQUIRED"}, 403
+            # Subscription gate. Controlled by Config.ENFORCE_SUBSCRIPTION_GATE so
+            # the server can be deployed with the gate OFF while old mobile builds
+            # (which cannot handle `SUBSCRIPTION_REQUIRED`) are still in the wild.
+            # Subscription state is still tracked elsewhere — only enforcement is
+            # gated here. See config.py for the rollout rationale.
+            if Config.ENFORCE_SUBSCRIPTION_GATE:
+                gate_user = UserModel.get_by_id(voice.user_id)
+                if not gate_user:
+                    logger.warning("Voice %s owned by non-existent user %s", voice_id, voice.user_id)
+                    return False, {"error": "Voice owner account not found", "code": "USER_NOT_FOUND"}, 404
+                if not gate_user.can_generate:
+                    return False, {"error": "Subscription required", "code": "SUBSCRIPTION_REQUIRED"}, 403
 
             story = StoryModel.get_story_by_id(story_id)
             if not story:

--- a/docs/SUBSCRIPTION_MOBILE_REQUIREMENTS.md
+++ b/docs/SUBSCRIPTION_MOBILE_REQUIREMENTS.md
@@ -355,7 +355,103 @@ ANNUAL_SUBSCRIPTION_CREDITS = int(os.getenv("ANNUAL_SUBSCRIPTION_CREDITS", "30")
 
 ---
 
-## 10. Mobile Contract Reference
+## 10. Subscription Gate Feature Flag (Rollout Safety)
+
+The audio synthesis gate in `controllers/audio_controller.py` is controlled
+by an environment variable so the server can be deployed with subscription
+infrastructure live but enforcement disabled. This is necessary because the
+mobile build without the subscription UI cannot handle a `403
+SUBSCRIPTION_REQUIRED` response — old clients in the App Store / Play Store
+would be bricked the moment the gate became active.
+
+### The flag
+
+```python
+Config.ENFORCE_SUBSCRIPTION_GATE  # env: ENFORCE_SUBSCRIPTION_GATE
+```
+
+Default: `false` (gate bypassed).
+Truthy values: `true`, `1`, `yes`, `on` (case-insensitive).
+
+### What the flag controls
+
+**Only one thing**: the subscription check in `AudioController.synthesize_audio()`.
+When OFF, the gate block is skipped entirely — no user lookup, no
+`can_generate` check, no 403 response. Old clients see identical behavior to
+pre-subscription-merge.
+
+### What the flag does NOT control
+
+All of this remains fully functional regardless of the flag state:
+
+- `GET /api/user/subscription-status` — still returns real trial/subscription state
+- `POST /api/user/link-revenuecat` — still binds users to RevenueCat
+- `POST /api/credits/grant-addon` — still grants add-on credits
+- `POST /api/webhooks/revenuecat` — still processes lifecycle events
+- Webhook credit grants (monthly / yearly subscribers)
+- Scheduled billing tasks (`grant_yearly_subscriber_monthly_credits`, `expire_credit_lots`)
+- `trial_expires_at` backfill on new signups
+- Migration `b7e8f9a0c1d2` (schema + historical trial backfill)
+
+The subscription state is always tracked correctly. The flag only affects
+**enforcement** in the audio endpoint.
+
+### Rollout plan
+
+1. Deploy server with `ENFORCE_SUBSCRIPTION_GATE` unset or `false`
+2. Old clients keep working; new clients on the updated build see the full
+   subscription experience because they pre-check `can_generate` via the
+   status endpoint and redirect to the paywall client-side
+3. Monitor App Store Connect / Play Console adoption metrics
+4. When ≥95% of daily-active users are on the new build, execute the
+   flip-day runbook below
+
+### Flip-day runbook
+
+**Step 1 — Refresh stale trials.** Users who signed up during the flag-off
+period had `trial_expires_at` set at registration, but the value is unused
+while the flag is off. By flip time some of those trials are already past.
+Run this SQL against the production database to give everyone without an
+active subscription a fresh 14-day trial window:
+
+```sql
+UPDATE users
+   SET trial_expires_at = NOW() + INTERVAL '14 days'
+ WHERE subscription_active = FALSE
+   AND revenuecat_app_user_id IS NULL;
+```
+
+Users who already subscribed keep their subscription. Users who linked
+RevenueCat (including trial users on the new app) keep their existing
+trial window.
+
+**Step 2 — Flip the flag.** Set `ENFORCE_SUBSCRIPTION_GATE=true` on the
+Render `dawnotemu-prod` env group. This triggers an auto-redeploy
+(~2 minutes).
+
+**Step 3 — Monitor.** Watch Sentry for `SUBSCRIPTION_REQUIRED` 403s and
+check the customer support inbox for the next hour.
+
+**Step 4 — Kill switch.** If anything breaks, set the flag back to `false`
+and redeploy. The rollback is instant and lossless: no subscription state
+is modified.
+
+### Testing
+
+The test suite defaults to `ENFORCE_SUBSCRIPTION_GATE = True` via a module-
+level assignment in `tests/conftest.py` so all existing gate tests exercise
+the fully-rolled-out behavior. Two dedicated tests in
+`tests/test_controllers/test_audio_controller.py` use `monkeypatch` to cover
+the flag-off path:
+
+- `test_synthesize_audio_flag_off_allows_unsubscribed` — unsubscribed user
+  with expired trial can still synthesize
+- `test_synthesize_audio_flag_off_skips_user_lookup` — `UserModel.get_by_id`
+  is never called (no new error paths leak through)
+
+---
+
+## 11. Mobile Contract Reference
 
 The mobile app's expectations are defined in these files (source of truth):
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,6 +17,12 @@ collect_ignore = [
 from config import Config
 from database import db
 
+# The subscription gate defaults to OFF in production until the mobile rollout
+# completes, but tests exercise the fully-rolled-out behavior by default.
+# Individual tests that need to cover the flag-off path use monkeypatch to flip
+# this back to False. See config.py::ENFORCE_SUBSCRIPTION_GATE for rationale.
+Config.ENFORCE_SUBSCRIPTION_GATE = True
+
 
 @pytest.fixture(scope="session", autouse=True)
 def setup_test_environment():

--- a/tests/test_controllers/test_audio_controller.py
+++ b/tests/test_controllers/test_audio_controller.py
@@ -648,3 +648,92 @@ def test_synthesize_audio_allows_with_subscription(monkeypatch, dummy_session):
 
     assert success is True
     assert status_code == 200
+
+
+# ─── Feature flag: ENFORCE_SUBSCRIPTION_GATE ────────────────────────────────
+
+
+def test_synthesize_audio_flag_off_allows_unsubscribed(monkeypatch, dummy_session):
+    """
+    When the subscription gate flag is OFF, a user with no subscription and
+    no active trial MUST still be able to synthesize audio. This is the
+    compatibility guarantee for old mobile builds that cannot handle the
+    SUBSCRIPTION_REQUIRED error code.
+    """
+    from config import Config
+    monkeypatch.setattr(Config, "ENFORCE_SUBSCRIPTION_GATE", False)
+
+    voice = make_voice()
+    story = {"content": "Flag off story"}
+    audio_record = make_audio_record(status=AudioStatus.READY.value, s3_key="s3://off.mp3")
+
+    # Simulate a user who would be blocked if the gate were enforced
+    monkeypatch.setattr(
+        "controllers.audio_controller.UserModel.get_by_id",
+        lambda uid: make_gate_user(subscription_active=False, trial_is_active=False),
+    )
+    monkeypatch.setattr(
+        "controllers.audio_controller.VoiceModel.get_voice_by_id", lambda voice_id: voice
+    )
+    monkeypatch.setattr(
+        "controllers.audio_controller.StoryModel.get_story_by_id", lambda story_id: story
+    )
+    monkeypatch.setattr(
+        "controllers.audio_controller.AudioModel.find_or_create_audio_record",
+        lambda story_id, voice_id, user_id: audio_record,
+    )
+    monkeypatch.setattr(
+        "controllers.audio_controller.AudioModel.get_audio_presigned_url",
+        lambda voice_id, story_id, expires_in=3600: (True, "https://cdn/off.mp3"),
+    )
+
+    success, data, status_code = AudioController.synthesize_audio(voice.id, 5)
+
+    assert success is True
+    assert status_code == 200
+    assert data.get("code") != "SUBSCRIPTION_REQUIRED"
+
+
+def test_synthesize_audio_flag_off_skips_user_lookup(monkeypatch, dummy_session):
+    """
+    When the flag is OFF, the gate block MUST NOT run at all — including the
+    user-lookup side effect. This guarantees no new error paths leak through
+    for old clients (e.g. a transient `UserModel.get_by_id` failure should
+    never surface as 404 while the flag is off).
+    """
+    from config import Config
+    monkeypatch.setattr(Config, "ENFORCE_SUBSCRIPTION_GATE", False)
+
+    voice = make_voice()
+    story = {"content": "No lookup story"}
+    audio_record = make_audio_record(status=AudioStatus.READY.value, s3_key="s3://nl.mp3")
+
+    lookup_calls = {"count": 0}
+
+    def sentinel_lookup(uid):
+        lookup_calls["count"] += 1
+        raise AssertionError("UserModel.get_by_id must not be called when flag is OFF")
+
+    monkeypatch.setattr(
+        "controllers.audio_controller.UserModel.get_by_id", sentinel_lookup
+    )
+    monkeypatch.setattr(
+        "controllers.audio_controller.VoiceModel.get_voice_by_id", lambda voice_id: voice
+    )
+    monkeypatch.setattr(
+        "controllers.audio_controller.StoryModel.get_story_by_id", lambda story_id: story
+    )
+    monkeypatch.setattr(
+        "controllers.audio_controller.AudioModel.find_or_create_audio_record",
+        lambda story_id, voice_id, user_id: audio_record,
+    )
+    monkeypatch.setattr(
+        "controllers.audio_controller.AudioModel.get_audio_presigned_url",
+        lambda voice_id, story_id, expires_in=3600: (True, "https://cdn/nl.mp3"),
+    )
+
+    success, _, status_code = AudioController.synthesize_audio(voice.id, 5)
+
+    assert success is True
+    assert status_code == 200
+    assert lookup_calls["count"] == 0


### PR DESCRIPTION
## Summary

Adds a feature flag (`ENFORCE_SUBSCRIPTION_GATE`, default **false**) that controls the subscription gate in `audio_controller.synthesize_audio()`. This is a deployment-safety change: without it, the subscription merge (already on `main`) will lock out every user still on a mobile build that doesn't have the RevenueCat subscription UI.

## Why this matters

The subscription merge introduced a gate:

```python
gate_user = UserModel.get_by_id(voice.user_id)
if not gate_user.can_generate:
    return False, {"error": "Subscription required", "code": "SUBSCRIPTION_REQUIRED"}, 403
```

Combined with the migration that backfilled `trial_expires_at = created_at + 14 days` for every existing user, any account older than 14 days would hit this 403 the moment it tries to synthesize audio. Old mobile builds collapse all 403s to a generic error toast and have no way to subscribe, so users would be **completely locked out** of story generation with no recovery path until they update the app — and getting the update out depends on App Store review.

## What's flagged

**Exactly one block** in `controllers/audio_controller.py`:

```python
if Config.ENFORCE_SUBSCRIPTION_GATE:
    gate_user = UserModel.get_by_id(voice.user_id)
    if not gate_user:
        return False, {"error": "Voice owner account not found", "code": "USER_NOT_FOUND"}, 404
    if not gate_user.can_generate:
        return False, {"error": "Subscription required", "code": "SUBSCRIPTION_REQUIRED"}, 403
```

When `ENFORCE_SUBSCRIPTION_GATE=false`:
- The gate block is skipped entirely (no user lookup, no 403, no new error paths)
- Old clients see **identical behavior** to pre-subscription-merge
- New clients still pre-check `can_generate` via `/api/user/subscription-status` and redirect to the paywall client-side, so they work correctly too

## What's NOT flagged

Everything else stays live regardless of the flag:

| Feature | Status |
|---|---|
| `GET /api/user/subscription-status` | Always live — returns real state |
| `POST /api/user/link-revenuecat` | Always live — binds users to RC |
| `POST /api/credits/grant-addon` | Always live — addon purchases work |
| `POST /api/webhooks/revenuecat` | Always live — events are processed |
| Webhook credit grants (monthly / yearly) | Always fire on real purchases |
| Scheduled billing tasks | Always run — they filter on `subscription_plan` |
| `trial_expires_at` backfill for new signups | Always set |
| Migration `b7e8f9a0c1d2` | Already applied, passive data |

The flag controls **enforcement only**. Subscription state is always tracked accurately.

## Rollout plan

1. **Deploy this PR** with `ENFORCE_SUBSCRIPTION_GATE` unset or `false`. Old clients keep working.
2. Publish the new mobile build to both stores.
3. Monitor adoption via App Store Connect / Play Console.
4. When ≥95% of daily-active users are on the new build, execute the flip-day runbook.

### Flip-day runbook (documented in `SUBSCRIPTION_MOBILE_REQUIREMENTS.md §10`)

1. **Refresh stale trials.** Users who signed up during the flag-off period had `trial_expires_at` set at registration, but by flip time some of those trials are already past. Run:
   ```sql
   UPDATE users
      SET trial_expires_at = NOW() + INTERVAL '14 days'
    WHERE subscription_active = FALSE
      AND revenuecat_app_user_id IS NULL;
   ```
   Users who already subscribed or linked RevenueCat are left alone.

2. **Flip the flag.** Set `ENFORCE_SUBSCRIPTION_GATE=true` on the Render `dawnotemu-prod` env group. Auto-redeploy takes ~2 minutes.

3. **Monitor.** Watch Sentry for `SUBSCRIPTION_REQUIRED` 403s and the customer-support inbox for the next hour.

4. **Kill switch.** If anything breaks, set the flag back to `false` and redeploy. Rollback is instant and lossless — no subscription state is modified.

## Testing

- `tests/conftest.py` pins `Config.ENFORCE_SUBSCRIPTION_GATE = True` at module load so the existing gate tests exercise the fully-rolled-out behavior unchanged.
- Two new tests in `tests/test_controllers/test_audio_controller.py` cover the flag-off path:
  - `test_synthesize_audio_flag_off_allows_unsubscribed` — unsubscribed user with expired trial is still allowed through
  - `test_synthesize_audio_flag_off_skips_user_lookup` — `UserModel.get_by_id` is **never called** (sentinel raises on any call), proving no new error paths leak through when the flag is off

### Test results

```
tests/test_controllers/test_audio_controller.py ... 17 passed  (2 new)
full subscription slice                        ... 244 passed
```

Pre-existing infra test failures (Redis port conflict with another local project, `test_integration_revenuecat_live.py::test_project_exists` asserting the wrong project ID format) are unrelated to this PR — they reproduce identically on `main`.

## Files changed

- `config.py` — new `ENFORCE_SUBSCRIPTION_GATE` flag with env-var parsing
- `controllers/audio_controller.py` — wrap gate block in the flag check (and import `Config`)
- `tests/conftest.py` — pin gate ON for tests
- `tests/test_controllers/test_audio_controller.py` — two new flag-off regression tests
- `docs/SUBSCRIPTION_MOBILE_REQUIREMENTS.md` — new §10 documenting flag, rollout plan, and flip-day runbook

## Test plan

- [ ] Verify `test_audio_controller.py` passes (17/17)
- [ ] Verify full subscription slice passes (244 tests)
- [ ] Verify the staging/prod deploy does NOT set `ENFORCE_SUBSCRIPTION_GATE=true` (absence = off)
- [ ] Smoke test: hit `/voices/{id}/stories/{id}/audio` on a deployed instance as a user with `trial_expires_at` in the past → should work (flag off)
- [ ] When ready to flip: run the trial-refresh SQL in a transaction first to eyeball the row count, then commit, then flip the env var

🤖 Generated with [Claude Code](https://claude.com/claude-code)