### PR TITLE
fix(tests): green CI — voice status + RC project id normalization

### DIFF
--- a/tests/test_integration_revenuecat_live.py
+++ b/tests/test_integration_revenuecat_live.py
@@ -49,13 +49,23 @@ class TestRevenueCatAPIConnectivity:
         assert "items" in data
 
     def test_project_exists(self):
-        """Our project ID should be found in the projects list."""
+        """Our project ID should be found in the projects list.
+
+        RevenueCat's v2 API returns project IDs with a ``proj`` prefix (e.g.
+        ``proj802211a0``), while the URL path and the env var accept the
+        unprefixed form (``802211a0``). Normalize both sides before comparing.
+        """
         resp = requests.get(f"{_BASE}/projects", headers=_HEADERS, timeout=10)
         assert resp.status_code == 200
         data = resp.json()
-        project_ids = [p["id"] for p in data.get("items", [])]
-        assert _PROJECT_ID in project_ids, (
-            f"Expected {_PROJECT_ID} in projects, got: {project_ids}"
+
+        def _strip(p):
+            return p[len("proj"):] if p.startswith("proj") else p
+
+        expected = _strip(_PROJECT_ID)
+        project_ids = [_strip(p["id"]) for p in data.get("items", [])]
+        assert expected in project_ids, (
+            f"Expected {expected} in projects, got: {project_ids}"
         )
 
     def test_v2_key_rejected_by_v1(self):

--- a/tests/test_models/test_voice_model.py
+++ b/tests/test_models/test_voice_model.py
@@ -313,7 +313,9 @@ class TestVoiceModel:
 
         assert success is True
         assert fake_voice.recording_filesize == 1024
-        assert fake_voice.status == VoiceStatus.RECORDED
+        # process_voice_recording marks the voice READY so the mobile app's
+        # status polling resolves; remote slot allocation stays deferred.
+        assert fake_voice.status == VoiceStatus.READY
 
         event_types = [event.event_type for event in events]
         assert VoiceSlotEventType.RECORDING_PROCESSED in event_types


### PR DESCRIPTION
## Summary

Fix two pre-existing test failures that have been keeping CI red on \`main\` since commit \`9806801\`. With these two tiny changes the full test suite is green locally:

\`\`\`
docker compose run --rm web pytest
465 passed, 0 failed
\`\`\`

## The two bugs

### 1. \`test_process_voice_recording_updates_metadata\`

Commit \`9806801 fix: set voice status to READY after processing to unblock mobile signup\` intentionally changed \`process_voice_recording\` in \`tasks/voice_tasks.py:138\` to set \`voice.status = VoiceStatus.READY\` — this unblocks the mobile app's status polling after voice upload. The test assertion wasn't updated in that commit and was still checking for \`VoiceStatus.RECORDED\`.

The code is correct (the behavior change is intentional and load-bearing for mobile signup). The test is outdated. Updated the assertion and added a comment explaining why.

### 2. \`test_project_exists\`

Live integration test in \`test_integration_revenuecat_live.py\` that compares \`REVENUECAT_PROJECT_ID\` (e.g. \`802211a0\`) against project ids returned by the v2 API (e.g. \`proj802211a0\`). RevenueCat's v2 API returns project ids with a \`proj\` prefix, but the URL path and env var both accept the unprefixed form — so the env var was stored without the prefix, but the comparison failed.

Normalize both sides by stripping the optional \`proj\` prefix before comparing so the test passes regardless of which form is stored.

## Test plan

- [x] \`docker compose run --rm web pytest tests/test_models/test_voice_model.py::TestVoiceModel::test_process_voice_recording_updates_metadata\` — passes
- [x] \`docker compose run --rm web pytest tests/test_integration_revenuecat_live.py::TestRevenueCatAPIConnectivity\` — all 3 tests pass
- [x] \`docker compose run --rm web pytest\` — full suite: 465 passed, 0 failed
- [ ] CI runs full suite on PR and passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)