### PR TITLE
chore: timezone-aware datetime + webhook cleanup task

### DIFF
--- a/admin.py
+++ b/admin.py
@@ -6,6 +6,7 @@ import time
 from functools import wraps
 from datetime import datetime, timedelta
 
+from utils.time_utils import utc_now
 from flask import redirect, url_for, request, flash, session
 from flask_admin import Admin, AdminIndexView, BaseView, expose
 from flask_admin.contrib.sqla import ModelView
@@ -80,13 +81,13 @@ def is_authenticated():
     
     # Check session expiration
     last_activity = session.get('last_activity')
-    if not last_activity or (datetime.utcnow() - datetime.fromisoformat(last_activity) > 
+    if not last_activity or (utc_now() - datetime.fromisoformat(last_activity) > 
                             timedelta(seconds=int(os.getenv('SESSION_TIMEOUT', DEFAULT_SESSION_TIMEOUT)))):
         session.pop('admin_authenticated', None)
         return False
     
     # Update last activity time
-    session['last_activity'] = datetime.utcnow().isoformat()
+    session['last_activity'] = utc_now().isoformat()
     return True
 
 
@@ -102,7 +103,7 @@ def login_required(f):
 
 def check_rate_limit(ip_address):
     """Check if the IP has exceeded the login attempt rate limit."""
-    now = datetime.utcnow()
+    now = utc_now()
     
     # Clear old attempts
     for ip in list(login_attempts.keys()):
@@ -343,7 +344,7 @@ class VoiceSlotDashboardView(SecureBaseView):
             "slot_limit": slot_limit,
             "queue_length": VoiceSlotQueue.length(),
             "available_capacity": available_capacity,
-            "generated_at": datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S"),
+            "generated_at": utc_now().strftime("%Y-%m-%d %H:%M:%S"),
         }
 
         events = VoiceModel.recent_slot_events(30)
@@ -381,7 +382,7 @@ class VoiceSlotDashboardView(SecureBaseView):
             voice.slot_lock_expires_at = None
             voice.allocation_status = VoiceAllocationStatus.RECORDED
             voice.status = VoiceStatus.RECORDED
-            voice.last_used_at = datetime.utcnow()
+            voice.last_used_at = utc_now()
             VoiceSlotEvent.log_event(
                 voice_id=voice.id,
                 user_id=voice.user_id,
@@ -429,7 +430,7 @@ class CustomAdminIndexView(AdminIndexView):
         from datetime import datetime, timedelta
         from sqlalchemy import func
 
-        today = datetime.utcnow().date()
+        today = utc_now().date()
 
         # User stats
         total_users = User.query.count()
@@ -512,7 +513,7 @@ class CustomAdminIndexView(AdminIndexView):
             
             if authenticated:
                 session['admin_authenticated'] = True
-                session['last_activity'] = datetime.utcnow().isoformat()
+                session['last_activity'] = utc_now().isoformat()
                 flash('Login successful', 'success')
                 return redirect(url_for('.index'))
             
@@ -1033,7 +1034,7 @@ class UserModelView(SecureModelView):
             flash('User not found', 'error')
             return redirect(url_for('.index_view'))
 
-        now = datetime.utcnow()
+        now = utc_now()
         lots = (
             CreditLot.query
             .filter(

--- a/config.py
+++ b/config.py
@@ -185,6 +185,21 @@ class Config:
         logging.getLogger(__name__).warning("Invalid YEARLY_SUBSCRIPTION_MONTHLY_CREDITS=%r, using default 30", os.getenv("YEARLY_SUBSCRIPTION_MONTHLY_CREDITS"))
     YEARLY_SUBSCRIPTION_MONTHLY_CREDITS = _ysc_val if _ysc_val > 0 else 30
 
+    # Webhook event retention (days). The webhook_events idempotency table is
+    # append-only and used to dedupe RevenueCat redeliveries, which retry for
+    # ~72h max. Anything older is pure storage overhead. Set to 0 to disable
+    # the daily cleanup task.
+    try:
+        _wer_raw = os.getenv("WEBHOOK_EVENT_RETENTION_DAYS", "90")
+        _wer_val = int(_wer_raw) if str(_wer_raw).strip() != "" else 90
+    except Exception:
+        _wer_val = 90
+        logging.getLogger(__name__).warning(
+            "Invalid WEBHOOK_EVENT_RETENTION_DAYS=%r, using default 90",
+            os.getenv("WEBHOOK_EVENT_RETENTION_DAYS"),
+        )
+    WEBHOOK_EVENT_RETENTION_DAYS = _wer_val if _wer_val >= 0 else 90
+
     # Consumption priority: event -> monthly -> referral -> add_on -> free
     _csp_raw = os.getenv("CREDIT_SOURCES_PRIORITY", "event,monthly,referral,add_on,free")
     CREDIT_SOURCES_PRIORITY = [s.strip() for s in _csp_raw.split(',') if s.strip()]

--- a/controllers/admin_controller.py
+++ b/controllers/admin_controller.py
@@ -11,6 +11,8 @@ from urllib.parse import urlparse
 
 import requests
 
+from utils.time_utils import utc_now
+
 from database import db
 from models.story_model import Story
 from models.voice_model import VoiceModel, VoiceAllocationStatus
@@ -105,8 +107,8 @@ class AdminController:
                 content=story_data['content'],
                 cover_filename=story_data.get('cover_filename'),
                 s3_cover_key=story_data.get('s3_cover_key'),
-                created_at=datetime.utcnow(),
-                updated_at=datetime.utcnow()
+                created_at=utc_now(),
+                updated_at=utc_now()
             )
             
             db.session.add(new_story)
@@ -210,7 +212,7 @@ class AdminController:
                         story = Story.query.get(story_id)
                         if story:
                             story.s3_cover_key = s3_key
-                            story.updated_at = datetime.utcnow()
+                            story.updated_at = utc_now()
                             db.session.commit()
                             
                             result['story']['s3_cover_key'] = s3_key

--- a/controllers/auth_controller.py
+++ b/controllers/auth_controller.py
@@ -5,6 +5,7 @@ from models.user_model import UserModel, User
 from utils.email_service import EmailService
 from database import db
 from utils.validators import is_valid_email, validate_password
+from utils.time_utils import utc_now
 
 class AuthController:
     """Controller for authentication-related operations"""
@@ -273,7 +274,7 @@ class AuthController:
         Returns:
             str: JWT access token
         """
-        now = datetime.utcnow()
+        now = utc_now()
         payload = {
             'sub': user.id,
             'email': user.email,
@@ -300,7 +301,7 @@ class AuthController:
         Returns:
             str: JWT refresh token
         """
-        now = datetime.utcnow()
+        now = utc_now()
         payload = {
             'sub': user.id,
             'type': 'refresh',

--- a/controllers/subscription_controller.py
+++ b/controllers/subscription_controller.py
@@ -8,6 +8,7 @@ from database import db
 from models.user_model import User
 from models.webhook_event_model import WebhookEvent
 from models.credit_model import grant as credit_grant
+from utils.time_utils import utc_now, utc_from_timestamp
 
 
 logger = logging.getLogger(__name__)
@@ -43,7 +44,7 @@ def _parse_expiration_ms(value):
     if ms < _MIN_EXPIRATION_MS or ms > _MAX_EXPIRATION_MS:
         logger.error("expiration_at_ms out of range: %s", ms)
         return None
-    return datetime.utcfromtimestamp(ms / 1000.0)
+    return utc_from_timestamp(ms / 1000.0)
 
 
 def _resolve_store_source(store):
@@ -69,7 +70,7 @@ class SubscriptionController:
 
         days_remaining = 0
         if user.trial_expires_at and user.trial_is_active:
-            delta = user.trial_expires_at - datetime.utcnow()
+            delta = user.trial_expires_at - utc_now()
             days_remaining = max(0, delta.days)
 
         return True, {
@@ -239,7 +240,7 @@ def _handle_initial_purchase(user, event):
     if parsed_expiry:
         user.subscription_expires_at = parsed_expiry
     else:
-        fallback = datetime.utcnow() + timedelta(days=35)
+        fallback = utc_now() + timedelta(days=35)
         user.subscription_expires_at = fallback
         logger.error(
             "INITIAL_PURCHASE for user %s has no valid expiration_at_ms — using 35-day fallback (%s)",
@@ -254,7 +255,7 @@ def _handle_renewal(user, event):
     if parsed_expiry:
         user.subscription_expires_at = parsed_expiry
     else:
-        fallback = datetime.utcnow() + timedelta(days=35)
+        fallback = utc_now() + timedelta(days=35)
         user.subscription_expires_at = fallback
         logger.error(
             "RENEWAL for user %s has no valid expiration_at_ms — using 35-day fallback (%s)",
@@ -286,7 +287,7 @@ def _handle_expiration(user, event):
 
 def _handle_billing_issue(user, event):
     logger.warning("Billing issue for user %s: %s", user.id, event.get("id"))
-    user.billing_issue_at = datetime.utcnow()
+    user.billing_issue_at = utc_now()
 
 
 def _handle_product_change(user, event):

--- a/models/addon_transaction_model.py
+++ b/models/addon_transaction_model.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 
 from database import db
+from utils.time_utils import utc_now
 
 
 class ConsumedAddonTransaction(db.Model):
@@ -22,4 +23,4 @@ class ConsumedAddonTransaction(db.Model):
     product_id = db.Column(db.String(100), nullable=False)
     platform = db.Column(db.String(20), nullable=False)
     credits_granted = db.Column(db.Integer, nullable=False)
-    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+    created_at = db.Column(db.DateTime, default=utc_now, nullable=False)

--- a/models/audio_model.py
+++ b/models/audio_model.py
@@ -8,6 +8,7 @@ from datetime import datetime
 
 from database import db
 from utils.s3_client import S3Client
+from utils.time_utils import utc_now
 from config import Config
 from utils.voice_service import VoiceService
 
@@ -53,8 +54,8 @@ class AudioStory(db.Model):
     file_size_bytes = db.Column(db.Integer, nullable=True)
     
     # Metadata and tracking
-    created_at = db.Column(db.DateTime, default=datetime.utcnow)
-    updated_at = db.Column(db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+    created_at = db.Column(db.DateTime, default=utc_now)
+    updated_at = db.Column(db.DateTime, default=utc_now, onupdate=utc_now)
     
     def __repr__(self):
         return f"<AudioStory {self.id}: Story {self.story_id}, Voice {self.voice_id}>"

--- a/models/credit_model.py
+++ b/models/credit_model.py
@@ -10,6 +10,7 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from database import db
 from models.user_model import User
+from utils.time_utils import utc_now
 
 
 class CreditTransaction(db.Model):
@@ -27,8 +28,8 @@ class CreditTransaction(db.Model):
     story_id: Mapped[Optional[int]] = mapped_column(db.Integer, db.ForeignKey('stories.id', ondelete='SET NULL'), index=True)
     status: Mapped[str] = mapped_column(db.String(20), nullable=False, default='applied')
     metadata_json: Mapped[Optional[dict]] = mapped_column('metadata', db.JSON)
-    created_at: Mapped[datetime] = mapped_column(db.DateTime, default=datetime.utcnow, nullable=False)
-    updated_at: Mapped[datetime] = mapped_column(db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(db.DateTime, default=utc_now, nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(db.DateTime, default=utc_now, onupdate=utc_now, nullable=False)
 
     allocations = relationship('CreditTransactionAllocation', back_populates='transaction', cascade="all, delete-orphan")
 
@@ -42,8 +43,8 @@ class CreditLot(db.Model):
     amount_granted: Mapped[int] = mapped_column(db.Integer, nullable=False)
     amount_remaining: Mapped[int] = mapped_column(db.Integer, nullable=False)
     expires_at: Mapped[Optional[datetime]] = mapped_column(db.DateTime)
-    created_at: Mapped[datetime] = mapped_column(db.DateTime, default=datetime.utcnow, nullable=False)
-    updated_at: Mapped[datetime] = mapped_column(db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(db.DateTime, default=utc_now, nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(db.DateTime, default=utc_now, onupdate=utc_now, nullable=False)
 
     allocations = relationship('CreditTransactionAllocation', back_populates='lot', cascade="all, delete-orphan")
 
@@ -64,7 +65,7 @@ class InsufficientCreditsError(Exception):
 
 
 def _active_lots_query(user_id: int):
-    now = datetime.utcnow()
+    now = utc_now()
     return (
         db.session.query(CreditLot)
         .filter(
@@ -101,7 +102,7 @@ ALLOWED_TRANSACTION_TYPES = {"credit", "debit", "refund", "expire"}
 
 
 def _serialize_lot(lot: CreditLot, now: Optional[datetime] = None) -> Dict[str, Optional[str | int | bool]]:
-    now = now or datetime.utcnow()
+    now = now or utc_now()
     is_active = (lot.amount_remaining or 0) > 0 and (
         lot.expires_at is None or lot.expires_at > now
     )
@@ -196,7 +197,7 @@ def get_user_credit_summary(
     user = db.session.get(User, user_id)
     balance_cached = int(user.credits_balance or 0) if user else 0
 
-    now = datetime.utcnow()
+    now = utc_now()
     lots_query = (
         CreditLot.query.filter(CreditLot.user_id == user_id)
         .order_by(

--- a/models/story_model.py
+++ b/models/story_model.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from config import Config
 from database import db
 from utils.credits import calculate_required_credits
+from utils.time_utils import utc_now
 
 # Database Model
 class Story(db.Model):
@@ -17,8 +18,8 @@ class Story(db.Model):
     cover_filename = db.Column(db.String(255), nullable=True)
     s3_cover_key = db.Column(db.String(512), nullable=True)
     position = db.Column(db.Integer, nullable=False, default=9999)
-    created_at = db.Column(db.DateTime, default=datetime.utcnow)
-    updated_at = db.Column(db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+    created_at = db.Column(db.DateTime, default=utc_now)
+    updated_at = db.Column(db.DateTime, default=utc_now, onupdate=utc_now)
     
     def __repr__(self):
         return f"<Story {self.id}: {self.title}>"

--- a/models/user_model.py
+++ b/models/user_model.py
@@ -5,6 +5,7 @@ import logging
 from werkzeug.security import generate_password_hash, check_password_hash
 from flask import current_app
 from database import db
+from utils.time_utils import utc_now
 
 
 logger = logging.getLogger(__name__)
@@ -22,8 +23,8 @@ class User(db.Model):
     # Credits balance for Story Points (Punkty Magii)
     credits_balance = db.Column(db.Integer, nullable=False, default=0)
     last_login = db.Column(db.DateTime, nullable=True)
-    created_at = db.Column(db.DateTime, default=datetime.utcnow)
-    updated_at = db.Column(db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+    created_at = db.Column(db.DateTime, default=utc_now)
+    updated_at = db.Column(db.DateTime, default=utc_now, onupdate=utc_now)
 
     # Trial & Subscription
     trial_expires_at = db.Column(db.DateTime, nullable=True)
@@ -51,7 +52,7 @@ class User(db.Model):
         """Return True if the user's free trial has not yet expired."""
         if self.trial_expires_at is None:
             return False
-        return datetime.utcnow() < self.trial_expires_at
+        return utc_now() < self.trial_expires_at
 
     @property
     def subscription_is_active(self):
@@ -64,7 +65,7 @@ class User(db.Model):
             return False
         if self.subscription_expires_at is None:
             return False
-        return datetime.utcnow() < self.subscription_expires_at
+        return utc_now() < self.subscription_expires_at
 
     @property
     def can_generate(self):
@@ -124,8 +125,8 @@ class User(db.Model):
     def _generate_token(self, payload, expires_in):
         """Generate a JWT token with the given payload"""
         payload.update({
-            'exp': datetime.utcnow() + timedelta(seconds=expires_in),
-            'iat': datetime.utcnow(),
+            'exp': utc_now() + timedelta(seconds=expires_in),
+            'iat': utc_now(),
             'jti': str(uuid.uuid4())
         })
         return jwt.encode(
@@ -195,7 +196,7 @@ class UserModel:
             is_admin=is_admin,
             is_active=is_active,
             credits_balance=0,
-            trial_expires_at=datetime.utcnow() + timedelta(days=trial_days),
+            trial_expires_at=utc_now() + timedelta(days=trial_days),
         )
         user.set_password(password)
         
@@ -261,7 +262,7 @@ class UserModel:
         """Update user's last login timestamp"""
         user = UserModel.get_by_id(user_id)
         if user:
-            user.last_login = datetime.utcnow()
+            user.last_login = utc_now()
             db.session.commit()
     
     @staticmethod

--- a/models/voice_model.py
+++ b/models/voice_model.py
@@ -12,6 +12,7 @@ from database import db
 from datetime import datetime
 from sqlalchemy import text
 from utils.voice_service import VoiceService
+from utils.time_utils import utc_now
 
 # Configure logger
 logger = logging.getLogger('voice_model_service')
@@ -99,8 +100,8 @@ class Voice(db.Model):
         lazy=True
     )
     
-    created_at = db.Column(db.DateTime, default=datetime.utcnow)
-    updated_at = db.Column(db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+    created_at = db.Column(db.DateTime, default=utc_now)
+    updated_at = db.Column(db.DateTime, default=utc_now, onupdate=utc_now)
     
     def __repr__(self):
         return (
@@ -142,7 +143,7 @@ class VoiceSlotEvent(db.Model):
     event_type = db.Column(db.String(50), nullable=False)
     reason = db.Column(db.String(255), nullable=True)
     event_metadata = db.Column('metadata', db.JSON, nullable=True)
-    created_at = db.Column(db.DateTime, nullable=False, default=datetime.utcnow)
+    created_at = db.Column(db.DateTime, nullable=False, default=utc_now)
 
     voice = db.relationship('Voice', back_populates='slot_events')
     user = db.relationship('User', backref=db.backref('voice_slot_events', lazy=True))

--- a/models/webhook_event_model.py
+++ b/models/webhook_event_model.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 
 from database import db
+from utils.time_utils import utc_now
 
 
 class WebhookEvent(db.Model):
@@ -15,4 +16,4 @@ class WebhookEvent(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     event_id = db.Column(db.String(255), unique=True, nullable=False, index=True)
     event_type = db.Column(db.String(50), nullable=False)
-    processed_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+    processed_at = db.Column(db.DateTime, default=utc_now, nullable=False, index=True)

--- a/tasks/audio_tasks.py
+++ b/tasks/audio_tasks.py
@@ -10,6 +10,7 @@ from celery import Task
 
 from tasks import celery_app
 from database import db
+from utils.time_utils import utc_now
 
 # Configure logger
 logger = logging.getLogger("audio_tasks")
@@ -217,7 +218,7 @@ def synthesize_audio_task(self, audio_story_id, voice_id, story_id, text, attemp
         # Acquire warm-hold lock BEFORE synthesis to prevent eviction during the operation
         warm_hold_seconds = getattr(Config, "VOICE_WARM_HOLD_SECONDS", 900) or 0
         if warm_hold_seconds > 0:
-            now = datetime.utcnow()
+            now = utc_now()
             # Lock for duration of synthesis TTL + warm-hold window
             voice.slot_lock_expires_at = now + timedelta(seconds=limiter_ttl + warm_hold_seconds)
             db.session.commit()
@@ -303,7 +304,7 @@ def synthesize_audio_task(self, audio_story_id, voice_id, story_id, text, attemp
                 logger.error("Refund failed for audio %s: %s", audio_story_id, refund_exc)
             return False
 
-        now = datetime.utcnow()
+        now = utc_now()
         voice.last_used_at = now
         warm_hold_seconds = getattr(Config, "VOICE_WARM_HOLD_SECONDS", 900) or 0
         if warm_hold_seconds > 0:

--- a/tasks/billing_tasks.py
+++ b/tasks/billing_tasks.py
@@ -13,6 +13,7 @@ from models.credit_model import (
     CreditTransactionAllocation,
     grant as credit_grant,
 )
+from utils.time_utils import utc_now
 
 logger = logging.getLogger('billing_tasks')
 
@@ -31,7 +32,7 @@ def grant_monthly_credits():
         logger.info('Monthly credit grants disabled (amount=%s). Skipping.', amount)
         return
 
-    now = datetime.utcnow()
+    now = utc_now()
     start_of_month = now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
     # Compute next month start
     if start_of_month.month == 12:
@@ -100,7 +101,7 @@ def grant_yearly_subscriber_monthly_credits():
         logger.info('Yearly monthly credit grants disabled (amount=%s).', amount)
         return
 
-    now = datetime.utcnow()
+    now = utc_now()
     start_of_month = now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
     if start_of_month.month == 12:
         next_month = start_of_month.replace(year=start_of_month.year + 1, month=1)
@@ -171,7 +172,7 @@ def expire_credit_lots():
     - Records ledger entries (CreditTransaction + allocations) describing each expiry.
     - Decreases users.credits_balance by the total amount removed per user (not below 0).
     """
-    now = datetime.utcnow()
+    now = utc_now()
     query = (
         db.session.query(CreditLot)
         .filter(
@@ -241,6 +242,50 @@ def expire_credit_lots():
         raise
 
 
+@celery_app.task(name='billing.cleanup_old_webhook_events', base=FlaskTask, ignore_result=True)
+def cleanup_old_webhook_events():
+    """Prune ``webhook_events`` rows older than ``WEBHOOK_EVENT_RETENTION_DAYS``.
+
+    The ``webhook_events`` table is append-only and used only for idempotency
+    on incoming RevenueCat webhook deliveries. Events that are older than the
+    retention window will never be re-delivered by RevenueCat (their retry
+    window is ~72 hours), so keeping them around is pure storage overhead.
+
+    Default retention: 90 days. Override via the
+    ``WEBHOOK_EVENT_RETENTION_DAYS`` environment variable. 0 disables the
+    task (useful for disabling pruning in environments that want full
+    historical data).
+
+    Uses a bulk ``DELETE`` keyed on the indexed ``processed_at`` column so
+    the operation is fast even on large tables. Commits in a single
+    transaction; rolls back cleanly on error.
+    """
+    # Local import to avoid a circular dependency at module load.
+    from models.webhook_event_model import WebhookEvent
+
+    retention_days = getattr(Config, 'WEBHOOK_EVENT_RETENTION_DAYS', 90)
+    if retention_days is None:
+        retention_days = 90
+    if retention_days <= 0:
+        logger.info('Webhook event cleanup disabled (retention_days=%s)', retention_days)
+        return
+
+    cutoff = utc_now() - timedelta(days=retention_days)
+    try:
+        deleted = db.session.query(WebhookEvent).filter(
+            WebhookEvent.processed_at < cutoff
+        ).delete(synchronize_session=False)
+        db.session.commit()
+        logger.info(
+            'Pruned %d webhook_events rows older than %s (retention=%d days)',
+            deleted, cutoff.isoformat(timespec='seconds'), retention_days,
+        )
+    except Exception as exc:
+        db.session.rollback()
+        logger.error('Failed to prune old webhook_events: %s', exc, exc_info=True)
+        raise
+
+
 # Schedule the expiration sweeper daily at 03:15 UTC
 _existing_schedule = getattr(celery_app.conf, 'beat_schedule', None) or {}
 celery_app.conf.beat_schedule = {
@@ -252,5 +297,9 @@ celery_app.conf.beat_schedule = {
     'yearly-subscriber-monthly-credits': {
         'task': 'billing.grant_yearly_subscriber_monthly_credits',
         'schedule': crontab(minute=30, hour=3),  # daily at 03:30 UTC
+    },
+    'cleanup-old-webhook-events': {
+        'task': 'billing.cleanup_old_webhook_events',
+        'schedule': crontab(minute=45, hour=3),  # daily at 03:45 UTC
     },
 }

--- a/tasks/voice_tasks.py
+++ b/tasks/voice_tasks.py
@@ -17,6 +17,7 @@ from config import Config
 from sqlalchemy import or_
 from utils.voice_slot_queue import VoiceSlotQueue
 from utils.metrics import emit_metric
+from utils.time_utils import utc_now
 
 # Configure logger
 logger = logging.getLogger('voice_tasks')
@@ -136,7 +137,7 @@ def process_voice_recording(self, voice_id, s3_key, filename, user_id, voice_nam
         # synthesis request (just-in-time via VoiceSlotManager.ensure_active_voice),
         # but the voice is usable from the user's perspective.
         voice.status = VoiceStatus.READY
-        voice.updated_at = datetime.utcnow()
+        voice.updated_at = utc_now()
 
         VoiceSlotEvent.log_event(
             voice_id=voice.id,
@@ -273,7 +274,7 @@ def reclaim_idle_voices(self, max_to_reclaim: Optional[int] = None):
         voice.elevenlabs_voice_id = None
         voice.elevenlabs_allocated_at = None
         voice.slot_lock_expires_at = None
-        voice.last_used_at = datetime.utcnow()
+        voice.last_used_at = utc_now()
         VoiceSlotEvent.log_event(
             voice_id=voice.id,
             user_id=voice.user_id,
@@ -283,7 +284,7 @@ def reclaim_idle_voices(self, max_to_reclaim: Optional[int] = None):
         )
         return True
 
-    now = datetime.utcnow()
+    now = utc_now()
     queue_length = VoiceSlotQueue.length()
     reclaimed = 0
 
@@ -349,7 +350,7 @@ def reset_stuck_allocations(self, max_to_reset: Optional[int] = None, stale_afte
         VoiceStatus,
     )
 
-    now = datetime.utcnow()
+    now = utc_now()
     stale_seconds = stale_after_seconds
     if stale_seconds is None:
         stale_seconds = getattr(Config, "VOICE_ALLOCATION_STUCK_SECONDS", 600) or 600
@@ -585,8 +586,8 @@ def allocate_voice_slot(self, voice_id, s3_key, filename, user_id, voice_name=No
             voice.allocation_status = VoiceAllocationStatus.READY
             # Persist the provider used for this allocation to keep capacity accounting consistent
             voice.service_provider = provider
-            voice.elevenlabs_allocated_at = datetime.utcnow()
-            voice.last_used_at = datetime.utcnow()
+            voice.elevenlabs_allocated_at = utc_now()
+            voice.last_used_at = utc_now()
             VoiceSlotQueue.remove(voice.id)
 
             VoiceSlotEvent.log_event(

--- a/tests/test_tasks/test_billing_tasks.py
+++ b/tests/test_tasks/test_billing_tasks.py
@@ -273,3 +273,111 @@ class TestExpireCreditLotsReraise:
             billing_tasks.expire_credit_lots()
 
         assert session.rollback_called is True
+
+
+class TestCleanupOldWebhookEvents:
+    """Regression for server#40: prune old rows from webhook_events.
+
+    The idempotency table is append-only and used only to dedupe RevenueCat
+    webhook redeliveries (retry window ~72h). Anything past the retention
+    window (default 90d) is pure storage overhead.
+    """
+
+    def _seed(self, ages_days):
+        """Insert one WebhookEvent per age in ``ages_days``. Returns list of ids."""
+        from models.webhook_event_model import WebhookEvent
+
+        now = datetime.utcnow()
+        ids = []
+        for i, age in enumerate(ages_days):
+            ev = WebhookEvent(
+                event_id=f'test_evt_{i}_{age}d',
+                event_type='TEST',
+                processed_at=now - timedelta(days=age),
+            )
+            db.session.add(ev)
+            db.session.flush()
+            ids.append(ev.id)
+        db.session.commit()
+        return ids
+
+    def test_prunes_events_older_than_retention(self, app):
+        from models.webhook_event_model import WebhookEvent
+
+        with app.app_context():
+            # Mix of old (>90d) and recent (<90d) events
+            self._seed([1, 30, 89, 91, 120, 400])
+
+            billing_tasks.cleanup_old_webhook_events()
+
+            remaining = db.session.query(WebhookEvent).all()
+            ages = sorted(
+                int((datetime.utcnow() - e.processed_at).days) for e in remaining
+            )
+            # Only the 1, 30, 89 day events should remain (all <90 cutoff)
+            assert ages == [1, 30, 89]
+
+    def test_noop_when_no_old_events(self, app):
+        from models.webhook_event_model import WebhookEvent
+
+        with app.app_context():
+            self._seed([1, 5, 10])
+
+            billing_tasks.cleanup_old_webhook_events()
+
+            assert db.session.query(WebhookEvent).count() == 3
+
+    def test_custom_retention_via_config(self, app, monkeypatch):
+        from models.webhook_event_model import WebhookEvent
+
+        with app.app_context():
+            self._seed([5, 15, 30])
+            # Retention window of 10 days → 15d and 30d get pruned
+            monkeypatch.setattr(
+                billing_tasks.Config, 'WEBHOOK_EVENT_RETENTION_DAYS', 10
+            )
+
+            billing_tasks.cleanup_old_webhook_events()
+
+            remaining = db.session.query(WebhookEvent).all()
+            ages = sorted(int((datetime.utcnow() - e.processed_at).days) for e in remaining)
+            assert ages == [5]
+
+    def test_disabled_when_retention_zero(self, app, monkeypatch):
+        from models.webhook_event_model import WebhookEvent
+
+        with app.app_context():
+            self._seed([1, 100, 500])
+            monkeypatch.setattr(
+                billing_tasks.Config, 'WEBHOOK_EVENT_RETENTION_DAYS', 0
+            )
+
+            billing_tasks.cleanup_old_webhook_events()
+
+            # Task should no-op; all 3 rows still present
+            assert db.session.query(WebhookEvent).count() == 3
+
+    def test_rollback_on_commit_failure(self, app, monkeypatch):
+        from models.webhook_event_model import WebhookEvent
+
+        with app.app_context():
+            self._seed([100, 200])
+
+            real_commit = db.session.commit
+            commit_calls = {'count': 0}
+
+            def failing_commit():
+                commit_calls['count'] += 1
+                raise RuntimeError("db down")
+
+            monkeypatch.setattr(db.session, 'commit', failing_commit)
+
+            with pytest.raises(RuntimeError, match="db down"):
+                billing_tasks.cleanup_old_webhook_events()
+
+            # Restore real commit so the fixture cleanup works
+            monkeypatch.setattr(db.session, 'commit', real_commit)
+            db.session.rollback()
+
+            # Both rows should still be present (rollback restored them)
+            assert db.session.query(WebhookEvent).count() == 2

--- a/utils/time_utils.py
+++ b/utils/time_utils.py
@@ -1,0 +1,41 @@
+"""Time utilities.
+
+Python 3.12+ deprecates ``datetime.utcnow()`` and ``datetime.utcfromtimestamp()``
+in favor of timezone-aware alternatives (``datetime.now(UTC)``,
+``datetime.fromtimestamp(ts, tz=UTC)``). However, the SQLAlchemy ``DateTime``
+columns used throughout this project are declared without ``timezone=True``,
+which means they store and return *naive* datetimes. Comparing a naive
+datetime to a timezone-aware datetime raises ``TypeError``.
+
+Rather than migrate every column to ``DateTime(timezone=True)`` (risky,
+requires a careful Alembic migration that interprets existing naive rows as
+UTC), we provide helper functions that return naive UTC datetimes. These are
+drop-in replacements for the deprecated calls and preserve the existing
+semantics exactly.
+
+If the DB schema is ever migrated to timezone-aware columns, simply change
+these helpers to return timezone-aware datetimes — every caller updates at
+once.
+"""
+
+from datetime import datetime, timezone
+
+
+def utc_now():
+    """Return the current UTC time as a naive ``datetime``.
+
+    Drop-in replacement for ``datetime.utcnow()``. Matches its semantics
+    exactly (naive datetime representing UTC) but avoids the Python 3.12+
+    deprecation warning.
+    """
+    return datetime.now(timezone.utc).replace(tzinfo=None)
+
+
+def utc_from_timestamp(ts):
+    """Return a naive UTC ``datetime`` from a POSIX timestamp.
+
+    Drop-in replacement for ``datetime.utcfromtimestamp(ts)``. Matches its
+    semantics exactly (naive UTC datetime) but avoids the Python 3.12+
+    deprecation warning.
+    """
+    return datetime.fromtimestamp(ts, tz=timezone.utc).replace(tzinfo=None)

--- a/utils/voice_slot_manager.py
+++ b/utils/voice_slot_manager.py
@@ -13,6 +13,7 @@ from models.voice_model import (
     VoiceStatus,
     VoiceModel,
 )
+from utils.time_utils import utc_now
 from utils.voice_slot_queue import VoiceSlotQueue
 from utils.redis_client import RedisClient
 from sqlalchemy.exc import InvalidRequestError
@@ -119,7 +120,7 @@ class VoiceSlotManager:
     def _extend_slot_lock(cls, voice: Voice) -> None:
         """Extend slot_lock_expires_at to prevent eviction during active use."""
         warm_hold = getattr(Config, "VOICE_WARM_HOLD_SECONDS", 900) or 900
-        voice.slot_lock_expires_at = datetime.utcnow() + timedelta(seconds=warm_hold)
+        voice.slot_lock_expires_at = utc_now() + timedelta(seconds=warm_hold)
         try:
             db.session.commit()
         except Exception:
@@ -187,7 +188,7 @@ class VoiceSlotManager:
         voice.status = VoiceStatus.PROCESSING
         voice.allocation_status = VoiceAllocationStatus.ALLOCATING
         voice.error_message = None
-        voice.slot_lock_expires_at = datetime.utcnow() + timedelta(seconds=lock_seconds)
+        voice.slot_lock_expires_at = utc_now() + timedelta(seconds=lock_seconds)
 
         VoiceSlotEvent.log_event(
             voice_id=voice.id,


### PR DESCRIPTION
Addresses two items from #40.

## Summary

- **datetime.utcnow migration**: introduce `utils/time_utils.py` with `utc_now()` and `utc_from_timestamp()` helpers that return naive UTC datetimes (matching the old semantics exactly), then replace every production call site. Silences the Python 3.12 deprecation warnings without requiring a schema migration to `DateTime(timezone=True)`.
- **webhook_events cleanup task**: new daily Celery Beat task `billing.cleanup_old_webhook_events` that prunes rows older than `WEBHOOK_EVENT_RETENTION_DAYS` (default 90 days, settable via env). Single-transaction bulk DELETE on an indexed column, scheduled at 03:45 UTC after the existing billing tasks.

## Why the helper approach instead of `datetime.now(timezone.utc)`?

SQLAlchemy `DateTime` columns in this project are declared without `timezone=True`, so they store and return naive datetimes. Swapping in `datetime.now(timezone.utc)` directly would break every comparison with a `TypeError: can't compare offset-naive and offset-aware datetimes`.

Two options:
1. Migrate every column to `DateTime(timezone=True)` + careful Alembic migration that interprets existing naive rows as UTC. Risky, invasive.
2. Helper returning `datetime.now(timezone.utc).replace(tzinfo=None)`. Zero behavioral change, silences the deprecation, single point-of-update for a future migration.

This PR goes with option 2.

## Files touched (18)

**Production code** (new deprecation-free, behavior identical):
- `utils/time_utils.py` *(new)*
- `config.py` — added `WEBHOOK_EVENT_RETENTION_DAYS` env var
- `admin.py`
- `controllers/{admin,auth,subscription}_controller.py`
- `models/{user,credit,voice,audio,story,addon_transaction,webhook_event}_model.py`
- `tasks/{billing,audio,voice}_tasks.py`
- `utils/voice_slot_manager.py`

**Tests**:
- `tests/test_tasks/test_billing_tasks.py` — 5 new tests in `TestCleanupOldWebhookEvents` covering normal prune, no-op when clean, custom retention, disabled-when-zero, rollback on commit failure.

**Deliberately left alone** (follow-up PR, non-blocking noise):
- `tests/**` — existing test files still use `datetime.utcnow` in fixtures. Tests pass, just emit warnings. Not worth churning every test file in this PR.
- `scripts/**` — one-off utility scripts
- `migrations/versions/**` — frozen history

## Webhook cleanup task details

```python
@celery_app.task(name='billing.cleanup_old_webhook_events', base=FlaskTask, ignore_result=True)
def cleanup_old_webhook_events():
    retention_days = getattr(Config, 'WEBHOOK_EVENT_RETENTION_DAYS', 90)
    if retention_days is None:
        retention_days = 90
    if retention_days <= 0:
        logger.info('Webhook event cleanup disabled (retention_days=%s)', retention_days)
        return

    cutoff = utc_now() - timedelta(days=retention_days)
    try:
        deleted = db.session.query(WebhookEvent).filter(
            WebhookEvent.processed_at < cutoff
        ).delete(synchronize_session=False)
        db.session.commit()
        logger.info('Pruned %d webhook_events rows older than %s', deleted, cutoff.isoformat())
    except Exception as exc:
        db.session.rollback()
        logger.error('Failed to prune old webhook_events: %s', exc, exc_info=True)
        raise
```

Also adds `index=True` to `WebhookEvent.processed_at` to make the cutoff query fast (was already noted in the model comment as 'for cleanup queries' but the index was missing).

## Rollout

- **Zero schema migration**: the `index=True` flag on `processed_at` is declarative — SQLAlchemy emits no DDL for it on existing columns. If you want the index materialized, run `flask db migrate -m 'index webhook_events processed_at'` followed by `flask db upgrade`. The task still works without the index, just slower on very large tables.
- **Env var**: `WEBHOOK_EVENT_RETENTION_DAYS` defaults to 90. Set to 0 to disable pruning.
- **Schedule**: `0 45 3 * * *` (daily at 03:45 UTC)
- **Safe to deploy**: existing tests all pass; no existing code path calls `cleanup_old_webhook_events` synchronously. Only Celery Beat invokes it.

## Test results

**329 tests pass** across every file this PR touches.

Pre-existing flake note: `test_billing_routes.py::test_get_credit_summary_with_history` already fails on `main` due to the JWT invalidation churn described in #45 (updated_at bump from CreditLot insert invalidates the token issued seconds earlier). Verified by running the test on a clean `main` checkout. Out of scope — covered by #45.

## Test plan

- [x] `pytest tests/test_tasks/test_billing_tasks.py -v` passes (12/12, including 5 new)
- [x] Full subscription slice passes (270 tests)
- [x] Model + route + util tests pass (no regressions from datetime helper)
- [ ] CI runs full suite on PR
- [ ] After merge: verify next Celery Beat cycle logs `Pruned N webhook_events rows` at 03:45 UTC

Closes part of #40.

🤖 Unattended overnight work while user was sleeping. Review before merge.